### PR TITLE
Additional tags for building and forwarding images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow specifying additional tags when building or forwarding an image on a per step basis.
+
+### Fixed
+
+- Documentation Typos
+
 ## [v1.0.0] - 2023-02-23
 
 ### Added

--- a/builderer/_documentation.py
+++ b/builderer/_documentation.py
@@ -37,6 +37,7 @@ step_build_dockerfile = "Path to Dockerfile. Name of the resulting image. Defaul
 step_build_name = "Name of the resulting image. Defaults to the name of the Dockerfiles parent directory."
 step_build_push = "Whether to push the image. Defaults to True."
 step_build_qualified = "Whether to add the registry path and prefix to the image name. Defaults to True."
+step_build_extra_tags = "Additional tags to use in this step. Defaults to None."
 
 step_extract_image = "Name of the image to copy from."
 step_extract_path = "Source path inside the image."
@@ -46,6 +47,7 @@ step_forward_name = "Image name to forward."
 step_forward_new_name = (
     "Set a new name for the image. By default the basename of the pulled image without the tag is used."
 )
+step_forward_extra_tags = "Additional tags to use in this step. Defaults to None."
 
 step_pull_name = "Image name to pull."
 step_pull_names = "Image names to pull."

--- a/builderer/config.py
+++ b/builderer/config.py
@@ -30,6 +30,7 @@ class BuildImage(_BaseModel):
     name: str | None = pydantic.Field(default=None, description=docs.step_build_name)
     push: bool = pydantic.Field(default=True, description=docs.step_build_push)
     qualified: bool = pydantic.Field(default=True, description=docs.step_build_qualified)
+    extra_tags: list[str] | None = pydantic.Field(default=None, description=docs.step_build_extra_tags)
 
     def add_to(self, builderer: builderer.Builderer) -> None:
         builderer.build_image(
@@ -38,6 +39,7 @@ class BuildImage(_BaseModel):
             name=self.name,
             push=self.push,
             qualified=self.qualified,
+            extra_tags=self.extra_tags,
         )
 
 
@@ -46,10 +48,16 @@ class BuildImages(_BaseModel):
     directories: list[str] = pydantic.Field(description=docs.step_build_directories)
     push: bool = pydantic.Field(default=True, description=docs.step_build_push)
     qualified: bool = pydantic.Field(default=True, description=docs.step_build_qualified)
+    extra_tags: list[str] | None = pydantic.Field(default=None, description=docs.step_build_extra_tags)
 
     def add_to(self, builderer: builderer.Builderer) -> None:
         for directory in self.directories:
-            builderer.build_image(directory=directory, push=self.push, qualified=self.qualified)
+            builderer.build_image(
+                directory=directory,
+                push=self.push,
+                qualified=self.qualified,
+                extra_tags=self.extra_tags,
+            )
 
 
 class ExtractFromImage(_BaseModel):
@@ -66,9 +74,14 @@ class ForwardImage(_BaseModel):
     type: typing.Literal["forward_image"] = pydantic.Field(description=docs.step_type)
     name: str = pydantic.Field(description=docs.step_forward_name)
     new_name: str | None = pydantic.Field(default=None, description=docs.step_forward_new_name)
+    extra_tags: list[str] | None = pydantic.Field(default=None, description=docs.step_forward_extra_tags)
 
     def add_to(self, builderer: builderer.Builderer) -> None:
-        builderer.forward_image(name=self.name, new_name=self.new_name)
+        builderer.forward_image(
+            name=self.name,
+            new_name=self.new_name,
+            extra_tags=self.extra_tags,
+        )
 
 
 class PullImage(_BaseModel):

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -127,6 +127,14 @@
           "description": "Whether to add the registry path and prefix to the image name. Defaults to True.",
           "default": true,
           "type": "boolean"
+        },
+        "extra_tags": {
+          "title": "Extra Tags",
+          "description": "Additional tags to use in this step. Defaults to None.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
@@ -166,6 +174,14 @@
           "description": "Whether to add the registry path and prefix to the image name. Defaults to True.",
           "default": true,
           "type": "boolean"
+        },
+        "extra_tags": {
+          "title": "Extra Tags",
+          "description": "Additional tags to use in this step. Defaults to None.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
@@ -234,6 +250,14 @@
           "title": "New Name",
           "description": "Set a new name for the image. By default the basename of the pulled image without the tag is used.",
           "type": "string"
+        },
+        "extra_tags": {
+          "title": "Extra Tags",
+          "description": "Additional tags to use in this step. Defaults to None.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,14 +113,15 @@ Each step may be one of
 
 #### BuildImage
 
-| Property   | Type          | Required | Description                                                                            |
-| ---------- | ------------- | -------- | -------------------------------------------------------------------------------------- |
-| type       | "build_image" | Yes      | Type of the step                                                                       |
-| directory  | string        | Yes      | Directory containing the Dockerfile. This is also used as the build context.           |
-| dockerfile | string        | No       | Path to Dockerfile. Name of the resulting image. Defaults to `<directory>/Dockerfile`. |
-| name       | string        | No       | Name of the resulting image. Defaults to the name of the Dockerfiles parent directory. |
-| push       | boolean       | No       | Whether to push the image. Defaults to True.                                           |
-| qualified  | boolean       | No       | Whether to add the registry path and prefix to the image name. Defaults to True.       |
+| Property   | Type            | Required | Description                                                                            |
+| ---------- | --------------- | -------- | -------------------------------------------------------------------------------------- |
+| type       | "build_image"   | Yes      | Type of the step                                                                       |
+| directory  | string          | Yes      | Directory containing the Dockerfile. This is also used as the build context.           |
+| dockerfile | string          | No       | Path to Dockerfile. Name of the resulting image. Defaults to `<directory>/Dockerfile`. |
+| name       | string          | No       | Name of the resulting image. Defaults to the name of the Dockerfiles parent directory. |
+| push       | boolean         | No       | Whether to push the image. Defaults to True.                                           |
+| qualified  | boolean         | No       | Whether to add the registry path and prefix to the image name. Defaults to True.       |
+| extra_tags | array of string | No       | Additional tags to use in this step. Defaults to None.                                 |
 
 ??? Example
 
@@ -138,6 +139,7 @@ Each step may be one of
 | directories | array of string | Yes      | Directories containing each containing Dockerfile.                               |
 | push        | boolean         | No       | Whether to push the image. Defaults to True.                                     |
 | qualified   | boolean         | No       | Whether to add the registry path and prefix to the image name. Defaults to True. |
+| extra_tags  | array of string | No       | Additional tags to use in this step. Defaults to None.                           |
 
 ??? Example
 
@@ -172,11 +174,12 @@ Each step may be one of
 
 #### ForwardImage
 
-| Property | Type            | Required | Description                                                                                        |
-| -------- | --------------- | -------- | -------------------------------------------------------------------------------------------------- |
-| type     | "forward_image" | Yes      | Type of the step                                                                                   |
-| name     | string          | Yes      | Image name to forward.                                                                             |
-| new_name | string          | No       | Set a new name for the image. By default the basename of the pulled image without the tag is used. |
+| Property   | Type            | Required | Description                                                                                        |
+| ---------- | --------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| type       | "forward_image" | Yes      | Type of the step                                                                                   |
+| name       | string          | Yes      | Image name to forward.                                                                             |
+| new_name   | string          | No       | Set a new name for the image. By default the basename of the pulled image without the tag is used. |
+| extra_tags | array of string | No       | Additional tags to use in this step. Defaults to None.                                             |
 
 ??? Example
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,7 @@ def test_build_image(dummy_builderer: AnyCaller) -> None:
         name="custom-name",
         push=False,
         qualified=False,
+        extra_tags=["additional_tag1", "extrac-2"],
     )
     tester.add_to(dummy_builderer)  # type: ignore
 
@@ -64,6 +65,7 @@ def test_build_image(dummy_builderer: AnyCaller) -> None:
                 "name": "custom-name",
                 "push": False,
                 "qualified": False,
+                "extra_tags": ["additional_tag1", "extrac-2"],
             },
         )
     ]
@@ -75,6 +77,7 @@ def test_build_images(dummy_builderer: AnyCaller) -> None:
         directories=["folder1", "folder2"],
         push=False,
         qualified=False,
+        extra_tags=["additional_tag1", "extrac-2"],
     )
     tester.add_to(dummy_builderer)  # type: ignore
 
@@ -86,6 +89,7 @@ def test_build_images(dummy_builderer: AnyCaller) -> None:
                 "directory": "folder1",
                 "push": False,
                 "qualified": False,
+                "extra_tags": ["additional_tag1", "extrac-2"],
             },
         ),
         (
@@ -95,6 +99,7 @@ def test_build_images(dummy_builderer: AnyCaller) -> None:
                 "directory": "folder2",
                 "push": False,
                 "qualified": False,
+                "extra_tags": ["additional_tag1", "extrac-2"],
             },
         ),
     ]
@@ -120,9 +125,7 @@ def test_extract_from_image(dummy_builderer: AnyCaller) -> None:
 
 def test_forward_image(dummy_builderer: AnyCaller) -> None:
     tester = builderer.config.ForwardImage(
-        type="forward_image",
-        name="image-name",
-        new_name="something-else",
+        type="forward_image", name="image-name", new_name="something-else", extra_tags=["additional_tag1", "extrac-2"]
     )
     tester.add_to(dummy_builderer)  # type: ignore
 
@@ -133,6 +136,7 @@ def test_forward_image(dummy_builderer: AnyCaller) -> None:
             {
                 "name": "image-name",
                 "new_name": "something-else",
+                "extra_tags": ["additional_tag1", "extrac-2"],
             },
         )
     ]

--- a/tests/test_file_config.py
+++ b/tests/test_file_config.py
@@ -55,7 +55,13 @@ def test_load_example_workspace(datadir: pathlib.Path) -> None:
         },
         "steps": [
             {"type": "pull_images", "names": ["docker.io/python:alpine", "docker.io/nginx:alpine"]},
-            {"type": "forward_image", "name": "docker.io/redis:alpine", "new_name": None},
-            {"type": "build_images", "directories": ["frontend", "backend"], "push": True, "qualified": True},
+            {"type": "forward_image", "name": "docker.io/redis:alpine", "new_name": None, "extra_tags": None},
+            {
+                "type": "build_images",
+                "directories": ["frontend", "backend"],
+                "push": True,
+                "qualified": True,
+                "extra_tags": None,
+            },
         ],
     }


### PR DESCRIPTION
Allow specifying additional tags when building or forwarding an image on a per step basis.

Also adapted test and documentation.