### PR TITLE
extract_from_image w/ full image names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow specifying additional tags when building or forwarding an image on a per step basis.
 
+### Changed
+
+- `extract_from_image` now requires full image names allowing extraction from remote images.
+
 ### Fixed
 
 - Documentation Typos

--- a/builderer/builderer.py
+++ b/builderer/builderer.py
@@ -147,13 +147,12 @@ class Builderer:
             path (str): Source path inside the image.
             dest (str): Destination paths. The file will be copied to all destinations individually.
         """
-        image_name = self._full_image_name(image)
         container_name = str(uuid.uuid4())
 
         self.action(
             name=f"Extracting from image: {path} -> {', '.join(dest)}",
             commands=[
-                [self.backend, "container", "create", "--name", container_name, image_name],
+                [self.backend, "container", "create", "--name", container_name, image],
                 *[[self.backend, "container", "cp", f"{container_name}:{path}", dst] for dst in dest],
                 [self.backend, "container", "rm", "-f", container_name],
             ],


### PR DESCRIPTION
`extract_from_image` now requires full image names allowing extraction from remote images.