### PR TITLE
publish docs on release only

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -2,8 +2,8 @@ name: Update Builderer Documentation
 
 on:
   workflow_dispatch:
-  push:
-    branches: ["main"]
+  release:
+    types: [published]
 
 permissions:
   contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `extract_from_image` now requires full image names allowing extraction from remote images.
+- Documentation will now only be published for new releases.
 
 ### Fixed
 


### PR DESCRIPTION
Documentation will now only be published for new releases.